### PR TITLE
adding missing peer port and beacon port (introduced by Patch #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,13 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - MAX_PLAYERS=${MAX_PLAYERS}
     ports:
-      # Port for connections from game client
+      # Game client port:
       - "7777:7777/udp"
-      # Steam's server-list port
+      # Peer port:
+      - "7778:7778/udp"
+      # Beacon port:
+      - "15000:15000"
+      # Steam server-list port:
       - "27015:27015/udp"
     networks:
       - default

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ services:
       # Peer port:
       - "7778:7778/udp"
       # Beacon port:
-      - "15000:15000"
+      - "15000:15000/udp"
       # Steam server-list port:
       - "27015:27015/udp"
     networks:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       # Peer port:
       - "7778:7778/udp"
       # Beacon port:
-      - "15000:15000"
+      - "15000:15000/udp"
       # Steam server-list port:
       - "27015:27015/udp"
     networks:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -20,9 +20,13 @@ services:
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}
       - MAX_PLAYERS=${MAX_PLAYERS}
     ports:
-      # Port for connections from game client
+      # Game client port:
       - "7777:7777/udp"
-      # Steam's server-list port
+      # Peer port:
+      - "7778:7778/udp"
+      # Beacon port:
+      - "15000:15000"
+      # Steam server-list port:
       - "27015:27015/udp"
     networks:
       - default


### PR DESCRIPTION
First of all - thank you for this repository - setting up Mordhau server was piece of cake using it.

I ran into problem with not being able to connect to server. It was fixed by adding those two ports.

Beacon port was introduced quite recently: https://steamcommunity.com/games/629760/announcements/detail/1617266961416483617

Not sure about how/where peer port is used - but adding it helped.

Cheers
